### PR TITLE
docs: clarify how to obtain METAAI_USERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ Il progetto utilizza le seguenti variabili d'ambiente configurabili tramite Dock
 
 #### Come ottenere `METAAI_USERNAME`
 
-Per ottenere il valore di `METAAI_USERNAME`, puoi fare riferimento alla seguente immagine:
+Per ottenere il valore di `METAAI_USERNAME`, Dopo il login sul tuo Meta AI vai su impostazioni di meta ai, e inserisci il tuo username senza il simbolo della "@" puoi fare riferimento alla seguente immagine:
 
-![Puoi trovare il tuo Meta AI Username dopo il login andando su impostazioni](Doc_Meta-AI-Wrapper_Username.png)
+
+![Puoi trovare il tuo Meta AI Username dopo il login andando su impostazioni ](Doc_Meta-AI-Wrapper_Username.png)
 
 
 


### PR DESCRIPTION
Improve instructions for METAAI_USERNAME README.
Explain after logging into Meta the user should open Meta AI settings and enter the username without the leading "@", and keep the existing reference image. This fixes an unclear one-line instruction by adding explicit steps so users can find and copy their username correctly.