### PR TITLE
feat: rename default model to meta-ai-openai-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Il progetto è containerizzato utilizzando Docker per facilitare la distribuzion
 Naviga nella directory principale del progetto dove si trova il `Dockerfile` ed esegui il seguente comando:
 
 ```bash
-docker build -t meta-ai-wrap .
+docker build -t meta-ai-openai-proxy .
 ```
 
 ### 2. Acquisire i Cookie di Sessione (Prima Esecuzione o Rinnovo)
@@ -43,7 +43,7 @@ Per interagire con Meta AI, è necessario acquisire i cookie di sessione. Questo
 Per eseguire `grab_cookies.py` e salvare i cookie in un volume persistente, usa il seguente comando:
 
 ```bash
-docker run -it -v /percorso/sul/tuo/host:/app/data -e APP_MODE=grab_cookies -e WEBDRIVER_URL="http://127.0.0.1:4444" meta-ai-wrap
+docker run -it -v /percorso/sul/tuo/host:/app/data -e APP_MODE=grab_cookies -e WEBDRIVER_URL="http://127.0.0.1:4444" -e METAAI_USERNAME="fiascojob" meta-ai-openai-proxy
 ```
 
 - Sostituisci `/percorso/sul/tuo/host` con un percorso assoluto sul tuo sistema host dove vuoi che il file `session_data.json` venga salvato (es. `/c/Users/TuoUtente/meta_ai_data` su Windows con Git Bash/WSL, o `/home/tuoutente/meta_ai_data` su Linux/macOS).
@@ -58,7 +58,7 @@ Dopo aver eseguito il comando, si aprirà una finestra del browser. Effettua il 
 Una volta acquisiti i cookie, puoi avviare il server FastAPI. Questo server utilizzerà i cookie salvati per interagire con Meta AI.
 
 ```bash
-docker run -p 8000:8000 -v /percorso/sul/tuo/host:/app/data -e WEBDRIVER_URL="http://127.0.0.1:4444" -e SELENIUM_HEADLESS="true" meta-ai-wrap
+docker run -p 8000:8000 -v /percorso/sul/tuo/host:/app/data -e WEBDRIVER_URL="http://127.0.0.1:4444" -e SELENIUM_HEADLESS="true" -e METAAI_USERNAME="fiascojob" meta-ai-openai-proxy
 ```
 
 - `-p 8000:8000`: Mappa la porta 8000 del container alla porta 8000 del tuo host.

--- a/example_1_send_request_openAI_compatible.py
+++ b/example_1_send_request_openAI_compatible.py
@@ -7,7 +7,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="meta-ai-wrap",
+    model="meta-ai-openai-proxy",
     messages=[{"role": "user", "content": "Chi è Ugo Fiasconaro?"}]
 )
 

--- a/example_2_send_request_openAI_compatible.py
+++ b/example_2_send_request_openAI_compatible.py
@@ -7,7 +7,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-    model="meta-ai-wrap",
+    model="meta-ai-openai-proxy",
     messages=[{"role": "user", "content": "Previsioni meteo del 14 agosto 2025 a Torino"}]
 
 )

--- a/send_message.py
+++ b/send_message.py
@@ -408,7 +408,7 @@ async def chat_completions(request: Request):
     data = await request.json()
     async with processing_lock_request:
         user_message = data["messages"][-1]["content"]
-        model = data.get("model", "meta-ai-wrap")  # fallback
+        model = data.get("model", "meta-ai-openai-proxy")  # fallback
 
         # Estrai risposta dalla Web UI
         try:
@@ -506,7 +506,7 @@ webdriver_url = os.getenv("WEBDRIVER_URL", "http://127.0.0.1:4444")
 session_data = load_session_data()
 
 # Simuliamo una lista di modelli disponibili
-AVAILABLE_MODELS = ["meta-ai-wrap"]
+AVAILABLE_MODELS = ["meta-ai-openai-proxy"]
 
 
 


### PR DESCRIPTION
Update code and documentation to use meta-ai-openai-proxy as the default model and Docker image name. Change affects example client scripts, server defaults, and README usage instructions.

- Switch examples (example_1/2) to model="meta-ai-openai-proxy".
- Update send_message.py fallback model and AVAILABLE_MODELS to the new name.
- Adjust README Docker build and run commands to tag and run meta-ai-openai-proxy and add METAAI_USERNAME in example run env.

This clarifies the project image/model naming and aligns defaults for local usage and documentation.