### PR TITLE
feat: add docker setup and update base Python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-alpine
+FROM python:3.13-alpine
 
 # Set the working directory in the container
 WORKDIR /app
@@ -7,6 +7,7 @@ WORKDIR /app
 # Copy the current directory contents into the container at /app
 COPY . /app
 RUN chmod +x /app/entrypoint.sh
+RUN sed -i 's/\r$//' /app/entrypoint.sh
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  selenium:
+    image: selenium/standalone-chrome:latest
+    ports:
+      - "7900:7900"
+    shm_size: 2gb
+    environment:
+      - SE_SUPERVISORD_UNIX_SERVER_PASSWORD=${SE_SUPERVISORD_UNIX_SERVER_PASSWORD}
+
+  meta-ai-proxy:
+    build: .
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./data:/app/data
+    environment:
+      - WEBDRIVER_URL=http://selenium:4444
+      - SELENIUM_HEADLESS=true
+      - METAAI_USERNAME=fiascojob
+      - DEBUG_ENABLED=false
+    depends_on:
+      - selenium


### PR DESCRIPTION
Add a docker-compose service stack and adjust the Dockerfile to support local development and Selenium-based UI testing.

- Add docker-compose.yml defining two services:
  - selenium: runs selenium/standalone-chrome with VNC port 7900, 2GB shm, and a supervisord password from env for secure access.
  - meta-ai-proxy: builds the app image, exposes port 8000, mounts ./data into /app/data, and wires environment variables for the WebDriver, headless mode, username, and debug flag. Depends on selenium so tests can run against the browser service.
- Upgrade Dockerfile base image from python:3.9-alpine to python:3.13-alpine to use a newer Python runtime.
- Ensure entrypoint script is executable and normalize line endings (strip CR) to avoid shell issues in the Alpine container.
- Keep pip installs cached-off for lean images.

These changes enable reproducible local deployments and browser-driven integration tests while fixing cross-platform script execution issues.