### PR TITLE
chore(docker): persist session data and use proxy image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+data/session_data.json


### PR DESCRIPTION
Add data/session_data.json to .dockerignore to avoid committing runtime session files This prevents accidental check-in of session state and keeps the repository clean.

Switch meta-ai-proxy from a local build to the prebuilt image ugofiasconaro/meta-ai-openai-proxy:latest in docker-compose.yml so deployments use the published image instead of building locally.

Also make METAAI_USERNAME configurable via environment by replacing the hardcoded username with ${METAAI_USERNAME}, allowing per-deployment credentials without editing the compose file.