### PR TITLE
feat: improve local chat stubbing and Selenium messaging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - SE_SUPERVISORD_UNIX_SERVER_PASSWORD=${SE_SUPERVISORD_UNIX_SERVER_PASSWORD}
 
   meta-ai-proxy:
-    build: .
+    image: ugofiasconaro/meta-ai-openai-proxy:latest
     ports:
       - "8000:8000"
     volumes:
@@ -18,7 +18,7 @@ services:
     environment:
       - WEBDRIVER_URL=http://selenium:4444
       - SELENIUM_HEADLESS=true
-      - METAAI_USERNAME=fiascojob
+      - METAAI_USERNAME=${METAAI_USERNAME}
       - DEBUG_ENABLED=false
     depends_on:
       - selenium

--- a/example_1_send_request_openAI_compatible.py
+++ b/example_1_send_request_openAI_compatible.py
@@ -8,7 +8,7 @@ client = OpenAI(
 
 response = client.chat.completions.create(
     model="meta-ai-openai-proxy",
-    messages=[{"role": "user", "content": "Chi è Ugo Fiasconaro?"}]
+    messages=[{"role": "user", "content": "Previsioni del meteo di domani ad Alessandria"}]
 )
 
 print(response.choices[0].message.content)

--- a/example_2_send_request_openAI_compatible.py
+++ b/example_2_send_request_openAI_compatible.py
@@ -1,15 +1,29 @@
 # Author: Ugo Fiasconaro
 from openai import OpenAI
 
-client = OpenAI(
-    base_url="http://localhost:8000/v1",  # Il tuo wrapper
-    api_key="null"
-)
+from openai.types.chat import ChatCompletion, ChatCompletionMessage
+from openai.types.chat.chat_completion import Choice
 
-response = client.chat.completions.create(
+# Costruisci manualmente la risposta senza chiamata HTTP
+response = ChatCompletion(
+    id="chatcmpl-123",
+    object="chat.completion",
+    created=int(time.time()),
     model="meta-ai-openai-proxy",
-    messages=[{"role": "user", "content": "Previsioni meteo del 14 agosto 2025 a Torino"}]
-
+    choices=[
+        Choice(
+            index=0,
+            message=ChatCompletionMessage(
+                role="assistant",
+                content="def hello_world():\n    print('Hello World')\n\nhello_world()"
+            ),
+            finish_reason="stop"
+        )
+    ],
+    usage={"prompt_tokens": 10, "completion_tokens": 15, "total_tokens": 25}
 )
 
 print(response.choices[0].message.content)
+print("############# New")
+import json
+print(response.model_dump_json(indent=4))


### PR DESCRIPTION
- Replace live HTTP chat completion call in example_2 with a manually constructed ChatCompletion instance (ChatCompletion, Choice, ChatCompletionMessage) to simulate responses without network calls. This enables offline testing and prints a formatted JSON dump of the response for debugging.
- Update example_1 prompt to use a weather query for Alessandria.
- Add missing imports and utilities in send_message.py (doctest.debug, uuid, Dict, Any) and import OpenAI chat types for potential local stubbing.
- Sanitize and split outgoing messages using markdownify, preserving line breaks and converting tabs to spaces, then send each line with Shift+Enter before final Enter to maintain message formatting in the web UI.
- Increase Selenium waits and add explicit sleeps and readyState checks (up to 120s) to improve stability when waiting for dynamic dialog elements and DOM readiness; increase wait timeout for locating the input field.
- Minor debug prints added to trace the generated message and verify document readiness.

These changes are done to enable robust local testing of chat output, preserve message formatting when sending through the browser UI, and reduce flaky failures by lengthening and adding explicit synchronization.