### PR TITLE
fix: limit noisy readyState logs behind DEBUG flag

### DIFF
--- a/send_message.py
+++ b/send_message.py
@@ -268,16 +268,17 @@ async def send_message_with_selenium (message, driver, previous_chatID=""):
                     WebDriverWait(driver, 120).until(
                         lambda driver: driver.execute_script("return document.readyState") == "complete"
                     )
-                    print("Document.readyState Completato con successo")
+                    if DEBUG_ENABLED.lower() == "true":
+                        print("Document.readyState Completato con successo")
                     time.sleep(1) # Aggiunto un piccolo ritardo per stabilizzare il DOM
 
 
 
-                    WebDriverWait(driver, 120).until(
-                        lambda driver: driver.execute_script("return document.readyState") == "complete"
-                    )
-                    print("Document.readyState Completato con successo")
-                    time.sleep(1) # Aggiunto un piccolo ritardo per stabilizzare il DOM
+                    # WebDriverWait(driver, 120).until(
+                    #     lambda driver: driver.execute_script("return document.readyState") == "complete"
+                    # )
+                    # print("Document.readyState Completato con successo")
+                    # time.sleep(1) # Aggiunto un piccolo ritardo per stabilizzare il DOM
 
                     WebDriverWait(driver, 120).until(
                             EC.visibility_of_element_located((By.XPATH, """//*[starts-with(@id, 'mount_0_0_')]//div[@dir='auto']"""))


### PR DESCRIPTION
Limit duplicate and noisy "Document.readyState Completato con successo" log output by logging it only when DEBUG_ENABLED is set to "true". Remove a redundant readyState wait/print/sleep block by commenting it out to avoid repeated waits and stabilize flow, while keeping the primary wait intact. This reduces console noise in normal runs and prevents unnecessary delays during execution, making debugging output conditional and behavior clearer.