### PR TITLE
fix(wait): wait for document ready after sending message

### DIFF
--- a/send_message.py
+++ b/send_message.py
@@ -170,8 +170,14 @@ async def send_message_with_selenium (message, driver, previous_chatID=""):
 
                     input_field.send_keys(Keys.RETURN)
                     
+                    WebDriverWait(driver, 120).until(
+                        lambda driver: driver.execute_script("return document.readyState") == "complete"
+                    )
+                    if DEBUG_ENABLED.lower() == "true":
+                        print("Document.readyState Completato con successo")
+                    time.sleep(1) # Aggiunto un piccolo ritardo per stabilizzare il DOM
                     
-                    time.sleep(1)
+                    
                     
                     wait = WebDriverWait(driver, 120)
                     alliconsBot = wait.until(


### PR DESCRIPTION
Add an explicit WebDriverWait that waits until document.readyState is "complete" immediately after sending the input/RETURN key. Keep a short time.sleep(1) to add a small stabilization delay for the DOM. Log a debug message when DEBUG_ENABLED is true.

This ensures subsequent DOM-dependent operations use a fully loaded page and reduces flaky failures caused by acting on an unstable DOM.