### PR TITLE
feat: stabilize navigation and message send flow

### DIFF
--- a/example_1_send_request_openAI_compatible.py
+++ b/example_1_send_request_openAI_compatible.py
@@ -2,13 +2,13 @@
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="http://localhost:8000/v1",  # Il tuo wrapper
+    base_url="http://localhost:8030/v1",  # Il tuo wrapper
     api_key="null"
 )
 
 response = client.chat.completions.create(
     model="meta-ai-openai-proxy",
-    messages=[{"role": "user", "content": "Previsioni del meteo di domani ad Alessandria"}]
+    messages=[{"role": "user", "content": "Oroscopo di Oggi\\nSagittario"}]
 )
 
 print(response.choices[0].message.content)


### PR DESCRIPTION
Wait for full document readiness before interacting pages and ensure the driver navigates to the intended previous chat only if the current URL does not already point to it. Add retries/delays and small sleeps to stabilize the DOM and avoid race conditions.

Improve message splitting and send behavior: treat single-line messages consistently, iterate with index, and use SHIFT+ENTER between lines to preserve intended newlines before finalizing with ENTER.

Relax element visibility checks when locating dynamic chat UI elements (to avoid false negatives) and add an error log when page load/waiting fails to aid debugging. Also perform a safe navigation back to the meta.ai root in the post-send flow to reset context.